### PR TITLE
Handling of invalid escape sequence '\]'

### DIFF
--- a/wininfparser.py
+++ b/wininfparser.py
@@ -862,7 +862,7 @@ class WinINF:
         f=open(Name,encoding=self.__FileCodec)
 
         #SepRE=re.compile('[^";=]*("|;|=)?')
-        SepRE = re.compile('[^][";=]*(]|\[|"|;|=)?')
+        SepRE = re.compile('[^][";=]*(\\]|\\[|"|;|=)?')
         KeyRE = re.compile('[^"]*(")')
         #ValueRE = re.compile('[^";=]*("|;)?')
         ValueRE = re.compile('[^";=]*("|;)?')

--- a/wininfparser.py
+++ b/wininfparser.py
@@ -862,7 +862,7 @@ class WinINF:
         f=open(Name,encoding=self.__FileCodec)
 
         #SepRE=re.compile('[^";=]*("|;|=)?')
-        SepRE = re.compile('[^][";=]*(\]|\[|"|;|=)?')
+        SepRE = re.compile('[^][";=]*(]|\[|"|;|=)?')
         KeyRE = re.compile('[^"]*(")')
         #ValueRE = re.compile('[^";=]*("|;)?')
         ValueRE = re.compile('[^";=]*("|;)?')


### PR DESCRIPTION
To fix this warning:
```
.venv/lib/python3.11/site-packages/wininfparser.py:865
  /opt/cloud-desktop/.venv/lib/python3.11/site-packages/wininfparser.py:865: DeprecationWarning: invalid escape sequence '\]'
```